### PR TITLE
fixed memory leak

### DIFF
--- a/src/ofxHapPlayer.cpp
+++ b/src/ofxHapPlayer.cpp
@@ -1127,5 +1127,5 @@ void ofxHapPlayer::DecodedFrame::clear()
 {
     pts = AV_NOPTS_VALUE;
     duration = 0;
-    buffer.clear();
+    buffer.swap(vector<char>());
 }


### PR DESCRIPTION
buffer.clear() did not resized the buffer. So when the memory remained allocated.

swap the buffer with a vector of size 0 fixes the problem.

See : http://www.cplusplus.com/reference/vector/vector/clear/