### PR TITLE
fix/MacOS also needs dispatch.h

### DIFF
--- a/src/ofxHapPlayer.cpp
+++ b/src/ofxHapPlayer.cpp
@@ -46,6 +46,8 @@ extern "C" {
 #include <ppl.h>
 #elif defined(TARGET_LINUX)
 #include <dispatch/dispatch.h>
+#elif defined(TARGET_OSX)
+#include <dispatch/dispatch.h>
 #endif
 
 // This amount will be bufferred before and after the playhead


### PR DESCRIPTION
**My System:**

Apple M2 Max
64 GB Memory
Ventura 13.5.2
VS Code
Building with oF's default Makefile (

**Fix**

I was getting some compile errors and realized that what was needed was the `dispatch.h` file to be included. I added an "if" for MacOS target and now it compiles and works great.

Not sure if I'm missing something or if there's different way of resolving this!