### PR TITLE
Added canPlaythrough method

### DIFF
--- a/src/ofxHapPlayer.h
+++ b/src/ofxHapPlayer.h
@@ -56,7 +56,9 @@ public:
     
     virtual void                play() override;
     virtual void                stop() override;
-    
+
+    bool canPlaythrough(const std::string &name);
+
     virtual bool                isFrameNew() const override;
     virtual ofPixels&           getPixels() override;
     virtual const ofPixels&     getPixels() const override;


### PR DESCRIPTION
Prompted by the need to mix the ofxHapPlayer and the default ofVideoPlayer I needed a reliable method to interrogate the media before playing.

Now you can test it with the canPlaythrough boolean.

```
ofxHapPlayer = h_player;
ofVideoPlayer = v_player;
…
if (h_player.canPlaythrough("video.mov"))
{
        h_player.load("video.mov");
        h_player.setLoopState(getLoopType(loopState));
        h_player.setSpeed(speed);
        h_player.play();
}
else
{
        v_player.load("video.mov");
        v_player.setLoopState(getLoopType(loopState));
        v_player.setSpeed(speed);
        v_player.play();
}
```